### PR TITLE
Extend chart to allow namespaced dashboards

### DIFF
--- a/charts/opa-exporter/Chart.yaml
+++ b/charts/opa-exporter/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: opa-exporter
 description: Prometheus exporter for OPA Gatekeeper.
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: 0.0.4
 home: https://github.com/mcelep/opa-scorecard

--- a/charts/opa-exporter/templates/dashboard.yaml
+++ b/charts/opa-exporter/templates/dashboard.yaml
@@ -9,4 +9,5 @@ metadata:
   labels: {{- include "this.labels" . | nindent 4 }}
     grafana_dashboard: "1"
   name: {{ include "this.fullname" . }}
+  namespace: {{ default .Release.Namespace .Values.grafanaDashboard.namespace }}
 {{- end }}

--- a/charts/opa-exporter/values.yaml
+++ b/charts/opa-exporter/values.yaml
@@ -83,7 +83,9 @@ extraNetworkPolicy:
 
 grafanaDashboard:
   # -- Whether to install `grafanaDashboard` (as ConfigMap) or not
-  create: false
+  create: true
+  # -- If the dashboard shouldn't be deployed in the release namespace, specify the namespace here
+  namespace: ""
 
 podMonitor:
   # -- Whether to install `podMonitor` (for Gatekeeper) or not


### PR DESCRIPTION
Add the ability to define a namespace for the grafana dashboards being deployed, as it isn't an uncommon practice to have a collection of dashboards in another namespace.

This will allow us to deploy the configmap in our central prometheus namespace and allow us to monitor gatekeeper from the central prometheus.