### PR TITLE
Switch to main tag for chart mirroring

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ include:
 variables:
   NO_PROXY: ".telekom.net,.telekom.de,.t-online.corp,.otc-service.com,.t-internal.com,.devlab.de,.tmo,localhost,127.0.0.1,10.*,eks.amazonaws.com"
   PACKAGE_GIT_REPO: https://github.com/caas-team/opa-scorecard.git
-  PACKAGE_HELM_TAG: caas
+  PACKAGE_HELM_TAG: main
   PACKAGE_CHART_PATH: charts/opa-exporter
   IMAGE_REGISTRY: mtr.devops.telekom.de/caas
   IMAGE_NAME: opa-scorecard


### PR DESCRIPTION
This pull request updates the PACKAGE_HELM_TAG variable in the pipeline configuration to use the "main" tag instead of "caas". This ensures that the latest version of the chart is used for mirroring.